### PR TITLE
Inventory performance

### DIFF
--- a/hardwarecheckout/controllers/inventory.py
+++ b/hardwarecheckout/controllers/inventory.py
@@ -79,6 +79,7 @@ def inventory():
             lottery_items = lottery_query.filter_by(is_visible = True).all(),
             checkout_items = checkout_query.filter_by(is_visible = True).all(),
             free_items = free_query.filter_by(is_visible = True).all(),
+            counts = counts,
             requests = requests,
             RequestStatus=RequestStatus, user=user)
 

--- a/hardwarecheckout/controllers/inventory.py
+++ b/hardwarecheckout/controllers/inventory.py
@@ -8,6 +8,7 @@ from hardwarecheckout.models.inventory_entry import InventoryEntry
 from hardwarecheckout.models.inventory_entry import ItemType
 from hardwarecheckout.models.user import User
 from hardwarecheckout.models.request import Request, RequestStatus
+from hardwarecheckout.models.request_item import RequestItem
 
 from hardwarecheckout.forms.inventory_form import InventoryForm
 from hardwarecheckout.forms.inventory_update_form import InventoryUpdateForm
@@ -50,12 +51,22 @@ def inventory():
         item_type = ItemType.CHECKOUT)
     free_query = InventoryEntry.query.filter_by(
         item_type = ItemType.FREE)
-    # replaces property quantity for each item
-    counts = db.session.query(Item.entry_id, func.count(Item.entry_id))\
+
+    # total number of items that exist by id
+    total_item_quants = db.session.query(Item.entry_id, func.count(Item.entry_id))\
             .group_by(Item.entry_id)\
-            .filter_by(user_id = None)\
             .all()
-    counts = {id_: count for (id_, count) in counts}
+    # total number of items that have been requested and approved/fulfilled
+    requested_quants  = db.session.query(RequestItem.entry_id, func.count(RequestItem.entry_id))\
+            .group_by(RequestItem.entry_id)\
+            .filter(RequestItem.request_id == Request.id,
+                    Request.status.in_([RequestStatus.APPROVED,
+                                        RequestStatus.FULFILLED]))\
+            .all()
+    requested_quants = {id_: count for (id_, count) in requested_quants}
+
+    # number of items that are free to request
+    counts = {id_: count - requested_quants.get(id_, 0) for (id_, count) in total_item_quants}
 
     if user:
         requests = Request.query.filter(Request.user == user,

--- a/hardwarecheckout/templates/includes/macros/display_item.html
+++ b/hardwarecheckout/templates/includes/macros/display_item.html
@@ -1,4 +1,5 @@
-{% macro display_item(item, admin=False, requestable=False) -%}
+{% macro display_item(item, counts, admin=False, requestable=False) -%}
+{% set count = counts.get(item.id, 0) %}
 <div class="row" >
     <div class="ten wide column">
         <div class="ui items">
@@ -40,14 +41,14 @@
     </div>
     <div class="six wide right aligned column">
     {% if requestable %} 
-        {% if item.requires_checkout and (item.quantity == 0 and not config['ENABLE_WAITLIST']) %}
+        {% if item.requires_checkout and (count == 0 and not config['ENABLE_WAITLIST']) %}
             <div> <strong>Out of stock!</strong> </div> 
             <br>
         {% else %}
             {% if (admin and (item.requires_checkout or item.requires_lottery)) 
                 or (item.requires_checkout and config['DISPLAY_CHECKOUT_QUANTITY']) 
                 or (item.requires_lottery and config['DISPLAY_LOTTERY_QUANTITY']) %}
-                <div> <strong>Quantity:</strong> {{ item.quantity }} </div> 
+                <div> <strong>Quantity:</strong> {{ count }} </div> 
                 <br>
             {% endif %}
             {% if item.requires_checkout and not item.requires_lottery %}
@@ -55,7 +56,7 @@
                 <div class="ui action input">
                     <input type="number" name="quantity" value="1" min="1" max="5">
                     <button data-item-id="{{ item.id }}" type="submit" class="ui primary submit button">
-                    {% if item.quantity > 0 %}
+                    {% if count > 0 %}
                         Request Now                            
                     {% else %}
                         Add To Waitlist

--- a/hardwarecheckout/templates/pages/inventory.html
+++ b/hardwarecheckout/templates/pages/inventory.html
@@ -43,7 +43,7 @@
         <div class="content">
             <div class="ui stackable grid">
                 {% for item in category.list %}
-                    {{ display_item(item, user.is_admin, True) }}
+                    {{ display_item(item, counts, user.is_admin, True) }}
                 {% endfor %}
             </div>
         </div>

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -40,6 +40,10 @@ def request_item(app, id):
         quantity=1), 
         follow_redirects=True)
 
+def approve_request(app, id_):
+    return app.post('/request/{}/approve'.format(id_),
+                    follow_redirects=True)
+
 @contextmanager
 def captured_templates(app):
     recorded = []


### PR DESCRIPTION
I noticed that the load times for `/inventory` were around 2/3 seconds on my machine and so I investigated and found out that the issue was that the template called `item.quantity` for every item, each of which made two queries on the database. This pull request adds in queries at the inventory level to do the same job with fewer requests to the database.

The initial way I did the queries (ff47e60) actually changed the behaviour of the page as it only looked at requests that had been fulfilled without looking at those that had also been approved. cb0dfd2 changes this to fit with the current behaviour and looks at requests that are both approved and fulfilled.

There are also some whitespace changes in the below, since my editor was moaning at me about spaces at the end of lines.

I've written a more in-depth look at the issue available [here](http://www.cameronmacleod.com/blog/sqlalchemy-speed).

Any comments or suggestions on this pull request, or the changes within are welcome!